### PR TITLE
Sticky Navigation Bar

### DIFF
--- a/src/components/Mainheader.jsx
+++ b/src/components/Mainheader.jsx
@@ -20,7 +20,7 @@ function Mainheader() {
   const pathname = usePathname();
 
   return (
-    <div className="w-full h-32 relative bg-white flex-col justify-start items-start flex">
+    <div className="w-full h-32 fixed top-0 z-50 bg-white flex-col justify-start items-start flex">
       <div className="h-12 px-40 py-2 bg-primary flex-row justify-between items-center w-50 gap-4 flex">
         <div className="justify-start items-center gap-1  w-fit  flex">
           <HiOutlineMail className=" stroke-white " />


### PR DESCRIPTION
As a user, I want the navigation bar to remain visible as I scroll down the page, so I can access navigation links without scrolling back to the top.



ACCEPTANCE CRITERIA

a. Given I am on the website's main page
       When I scroll down the page
       Then I should see the navigation bar fixed at the top of the screen.
b. Given I am on the main page
    When I scroll down the page
    Then the navigation bar should not disappear or become hidden during scrolling